### PR TITLE
Fix typo in seed utility comment

### DIFF
--- a/opentad/utils/misc.py
+++ b/opentad/utils/misc.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 
 
 def set_seed(seed, disable_deterministic=False):
-    """Set randon seed for pytorch and numpy"""
+    """Set random seed for pytorch and numpy"""
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)


### PR DESCRIPTION
## Summary
- fix comment in `opentad/utils/misc.py`

## Testing
- `pytest -q` *(fails: command not found)*