### PR TITLE
Fix mAP multi-thread result lookup

### DIFF
--- a/opentad/evaluations/mAP.py
+++ b/opentad/evaluations/mAP.py
@@ -198,7 +198,7 @@ class mAP:
 
         ap = np.zeros((len(self.tiou_thresholds), len(self.activity_index.items())))
         for i, cidx in enumerate(self.activity_index.values()):
-            ap[:, cidx] = self.mAP_result_dict[i]
+            ap[:, cidx] = self.mAP_result_dict[cidx]
         return ap
 
     def multi_thread_compute_topkx_recall(self):
@@ -224,7 +224,7 @@ class mAP:
 
         recall = np.zeros((len(self.tiou_thresholds), len(self.top_k), len(self.activity_index.items())))
         for i, cidx in enumerate(self.activity_index.values()):
-            recall[..., cidx] = self.recall_result_dict[i]
+            recall[..., cidx] = self.recall_result_dict[cidx]
         return recall
 
     def evaluate(self):


### PR DESCRIPTION
## Summary
- fix incorrect key usage when aggregating per-class results in `mAP`

## Testing
- `pytest -q` *(fails: command not found)*