### PR TITLE
Handle missing DDP env vars

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -38,11 +38,22 @@ def main():
         cfg.merge_from_dict(args.cfg_options)
 
     # DDP init
-    args.local_rank = int(os.environ["LOCAL_RANK"])
-    args.world_size = int(os.environ["WORLD_SIZE"])
-    args.rank = int(os.environ["RANK"])
-    print(f"Distributed init (rank {args.rank}/{args.world_size}, local rank {args.local_rank})")
-    dist.init_process_group("nccl", rank=args.rank, world_size=args.world_size)
+    local_rank_env = os.environ.get("LOCAL_RANK")
+    world_size_env = os.environ.get("WORLD_SIZE")
+    rank_env = os.environ.get("RANK")
+    if (local_rank_env is not None) and (world_size_env is not None) and (rank_env is not None):
+        args.local_rank = int(local_rank_env)
+        args.world_size = int(world_size_env)
+        args.rank = int(rank_env)
+        print(f"Distributed init (rank {args.rank}/{args.world_size}, local rank {args.local_rank})")
+        dist.init_process_group("nccl", rank=args.rank, world_size=args.world_size)
+        ddp = True
+    else:
+        args.local_rank = 0
+        args.world_size = 1
+        args.rank = 0
+        ddp = False
+        print("DDP disabled. Running in a single process.")
     torch.cuda.set_device(args.local_rank)
 
     # set random seed, create work_dir
@@ -72,8 +83,11 @@ def main():
 
     # DDP
     model = model.to(args.local_rank)
-    model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank)
-    logger.info(f"Using DDP with total {args.world_size} GPUS...")
+    if ddp:
+        model = DistributedDataParallel(model, device_ids=[args.local_rank], output_device=args.local_rank)
+        logger.info(f"Using DDP with total {args.world_size} GPUS...")
+    else:
+        logger.info("DDP disabled. Using single GPU.")
 
     if cfg.inference.load_from_raw_predictions:  # if load with saved predictions, no need to load checkpoint
         logger.info(f"Loading from raw predictions: {cfg.inference.fuse_list}")


### PR DESCRIPTION
## Summary
- allow running `tools/train.py` and `tools/test.py` without DDP environment
- skip `dist.init_process_group` and `DistributedDataParallel` if env vars are absent
- log whether DDP is enabled or disabled

## Testing
- `python -m py_compile tools/train.py tools/test.py`